### PR TITLE
Add support for itemize/enumerate/item

### DIFF
--- a/src/lib/template/all-renderers.ts
+++ b/src/lib/template/all-renderers.ts
@@ -43,11 +43,14 @@ import {OuterEnvBlockMathRenderer} from './renderers/outer-env/block-math';
 import {OuterEnvCaptionRenderer} from './renderers/outer-env/caption';
 import {OuterEnvCodeblockRenderer} from './renderers/outer-env/codeblock';
 import {DefaultOuterEnvRenderer} from './renderers/outer-env/default';
+import {OuterEnvEnumerateRenderer} from './renderers/outer-env/enumerate';
 import {OuterEnvGatherMathRenderer} from './renderers/outer-env/gather-math';
 import {OuterEnvQuoteRenderer} from './renderers/outer-env/quote';
 import {OuterEnvSageRenderer} from './renderers/outer-env/sage';
 import {OuterEnvTabularRenderer} from './renderers/outer-env/tabular';
 import {OuterEnvTikzRenderer} from './renderers/outer-env/tikz';
+import {OuterEnvItemRenderer} from './renderers/outer-env/item';
+import {OuterEnvItemizeRenderer} from './renderers/outer-env/itemize';
 
 export function registerTemplateRenderers(): void {
     rendererRegistry.setRenderer(new DocumentRootRenderer());
@@ -83,11 +86,14 @@ export function registerTemplateRenderers(): void {
     rendererRegistry.setRenderer(new OuterEnvCaptionRenderer());
     rendererRegistry.setRenderer(new OuterEnvCodeblockRenderer());
     rendererRegistry.setRenderer(new OuterEnvBlockMathRenderer());
+    rendererRegistry.setRenderer(new OuterEnvEnumerateRenderer());
     rendererRegistry.setRenderer(new OuterEnvGatherMathRenderer());
     rendererRegistry.setRenderer(new OuterEnvSageRenderer());
     rendererRegistry.setRenderer(new OuterEnvTabularRenderer());
     rendererRegistry.setRenderer(new OuterEnvTikzRenderer());
     rendererRegistry.setRenderer(new OuterEnvQuoteRenderer());
+    rendererRegistry.setRenderer(new OuterEnvItemRenderer());
+    rendererRegistry.setRenderer(new OuterEnvItemizeRenderer());
 
     rendererRegistry.setRenderer(new DefaultInnerEnvRenderer());
     rendererRegistry.setRenderer(new InnerEnvCiteRenderer());

--- a/src/lib/template/renderers/outer-env/enumerate.ts
+++ b/src/lib/template/renderers/outer-env/enumerate.ts
@@ -1,0 +1,15 @@
+import {ASTNode} from '../../../core/ast/ast-node';
+import {Renderer} from '../../../core/rendering/renderer';
+import {RenderingManager} from '../../../core/rendering/rendering-manager';
+import {WooElementKind} from '../../../util/types/woo';
+
+export class OuterEnvEnumerateRenderer implements Renderer {
+    readonly kind: WooElementKind = 'OuterEnv';
+    readonly abstractVariant = 'enumerate';
+
+    render(renderingManager: RenderingManager, astNode: ASTNode): Node {
+        const enumerate = document.createElement('ol');
+        enumerate.append(renderingManager.render(...astNode.children));
+        return enumerate;
+    }
+}

--- a/src/lib/template/renderers/outer-env/item.ts
+++ b/src/lib/template/renderers/outer-env/item.ts
@@ -1,0 +1,15 @@
+import {ASTNode} from '../../../core/ast/ast-node';
+import {Renderer} from '../../../core/rendering/renderer';
+import {RenderingManager} from '../../../core/rendering/rendering-manager';
+import {WooElementKind} from '../../../util/types/woo';
+
+export class OuterEnvItemRenderer implements Renderer {
+    readonly kind: WooElementKind = 'OuterEnv';
+    readonly abstractVariant = 'item';
+
+    render(renderingManager: RenderingManager, astNode: ASTNode): Node {
+        const item = document.createElement('li');
+        item.append(renderingManager.render(...astNode.children));
+        return item;
+    }
+}

--- a/src/lib/template/renderers/outer-env/itemize.ts
+++ b/src/lib/template/renderers/outer-env/itemize.ts
@@ -1,0 +1,15 @@
+import {ASTNode} from '../../../core/ast/ast-node';
+import {Renderer} from '../../../core/rendering/renderer';
+import {RenderingManager} from '../../../core/rendering/rendering-manager';
+import {WooElementKind} from '../../../util/types/woo';
+
+export class OuterEnvItemizeRenderer implements Renderer {
+    readonly kind: WooElementKind = 'OuterEnv';
+    readonly abstractVariant = 'itemize';
+
+    render(renderingManager: RenderingManager, astNode: ASTNode): Node {
+        const itemize = document.createElement('ul');
+        itemize.append(renderingManager.render(...astNode.children));
+        return itemize;
+    }
+}

--- a/src/lib/template/variants.ts
+++ b/src/lib/template/variants.ts
@@ -24,14 +24,15 @@ export function registerTemplateVariants(): void {
     variantRegistry.setVariant('OuterEnv', 'align', 'align-math');
     variantRegistry.setVariant('OuterEnv', 'caption', 'caption');
     variantRegistry.setVariant('OuterEnv', 'codeblock', 'codeblock');
-    variantRegistry.setVariant('OuterEnv', 'enumerate', 'enumerate'); // TODO
+    variantRegistry.setVariant('OuterEnv', 'enumerate', 'enumerate');
     variantRegistry.setVariant('OuterEnv', 'equation', 'block-math');
     variantRegistry.setVariant('OuterEnv', 'gather', 'gather-math');
     variantRegistry.setVariant('OuterEnv', 'sage', 'sage');
     variantRegistry.setVariant('OuterEnv', 'tabular', 'tabular');
     variantRegistry.setVariant('OuterEnv', 'tikz', 'tikz');
     variantRegistry.setVariant('OuterEnv', 'image', 'image'); // TODO
-    variantRegistry.setVariant('OuterEnv', 'itemize', 'itemize'); // TODO
+    variantRegistry.setVariant('OuterEnv', 'itemize', 'itemize');
+    variantRegistry.setVariant('OuterEnv', 'item', 'item');
     variantRegistry.setVariant('OuterEnv', 'quote', 'quote');
 
     variantRegistry.setVariant('InnerEnv', 'cite', 'cite');


### PR DESCRIPTION
This is my attempt to add a simple support for inner environments `itemize` (unordered list), `enumerate` (ordered list) and `item` (list item). In the future there is a room for some simplified notation, but at the moment the following is OK:

```
.itemize:

  .item:

    First item

  .item:

    Second item
```

Similarly for `enumerate`.